### PR TITLE
Refactor list project

### DIFF
--- a/.well-known/ai-plugin.json
+++ b/.well-known/ai-plugin.json
@@ -2,8 +2,8 @@
     "schema_version": "v1",
     "name_for_human": "Nuvolaris Plugin",
     "name_for_model": "nuvolaris_plugin",
-    "description_for_human": "Find an organization repos on GitHub (made with Nuvolaris)",
-    "description_for_model": "Plugin for finding the list of repositories made by an organization on GitHub",
+    "description_for_human": "Find an organization repos on GitHub or a Figma file",
+    "description_for_model": "Retrieving repositories made by an organization on GitHub or Figma file",
     "auth": {
       "type": "none"
     },

--- a/.well-known/ai-plugin.json
+++ b/.well-known/ai-plugin.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "v1",
-    "name_for_human": "GitHub API Plugin with Nuvolaris",
-    "name_for_model": "github-api-nuvolaris",
+    "name_for_human": "Nuvolaris Plugin",
+    "name_for_model": "nuvolaris_plugin",
     "description_for_human": "Find an organization repos on GitHub (made with Nuvolaris)",
     "description_for_model": "Plugin for finding the list of repositories made by an organization on GitHub",
     "auth": {
@@ -14,5 +14,4 @@
     "logo_url": "https://gptuser.nuvgpt.n9s.cc/logo.jpg",
     "contact_email": "info@nuvolaris.io",
     "legal_info_url": "https://gptuser.nuvgpt.n9s.cc/legal.html"
-}
-  
+  }

--- a/list-project.py
+++ b/list-project.py
@@ -1,39 +1,45 @@
 import requests
-import json
 
-def main(args):
-    organization = args.get('organization')
-    github_token = args.get('GITHUB_TOKEN')
-        
-    if github_token is None:
-        return {'error': 'GitHub token not set'}
+def check_errors(response):
+    if response.status_code == 200:
+        return None
+    return {"body": f"error: Github API Error: {response.reason}"}
 
+def list_projects(organization, token):
+    if not organization or not token:
+        return {"body": "error: Missing organization or GitHub token"}
+    
     headers = {
-        'Authorization': f'Bearer {github_token}',
+        'Authorization': f'Bearer {token}',
         'Accept': 'application/vnd.github.v3+json'
     }
 
-    # Se non viene trovato il nome dell'organizzazione, restituisce un errore
-    if organization is None:
-        return {
-            'statusCode': 400,
-            'body': json.dumps({'error': 'Organization name not exists'})
-        }
-    
     url = f'https://api.github.com/orgs/{organization}/repos'
-    
+
     response = requests.get(url, headers=headers)
+
+    return response
+
+def main(args):
+    organization = args.get('organization')
+    token = args.get('githubtoken')
+    
+    response = list_projects(organization, token)
+    error = check_errors(response)
+
+    if error:
+        return {
+            'statusCode': response.status_code,
+            'body': error
+        }
 
     repositories = response.json()
     
     projects = {}
 
-    if response.status_code == 200:
-        for repo in repositories:
-            repo_name = repo["name"]
-            repo_description = repo["description"]
-            projects[repo_name] = repo_description
+    for repo in repositories:
+        repo_name = repo["name"]
+        repo_description = repo["description"]
+        projects[repo_name] = repo_description
 
-        return {'repos': projects}
-    else:
-        raise Exception(f"Error: {response.status_code}, {response.text}")
+    return {"body": projects}

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -9,3 +9,10 @@ packages:
       all-args:
         function: all-args.py
         web: true
+  figma-api:
+    actions:
+      figma-api:
+        function: figma-api.py
+        web: true
+        inputs:
+          apitoken: ${FIGMA_TOKEN}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,12 +1,12 @@
 openapi: 3.0.1
 info:
-  title: GitHub API Plugin
-  description: A plugin that retrieves a list of projects from GitHub for an organization using ChatGPT.
+  title: Nuvolaris API Plugin
+  description: A plugin that retrieves a list of projects from GitHub for an organization and retrieves a Figma file as a JSON.
   version: 'v1'
 servers:
-  - url: https://nuvgpt.n9s.cc/api/v1/web/nuvolaris/github-api
+  - url: https://gptuser.nuvgpt.n9s.cc/api/my
 paths:
-  /list-project:
+  github-api/list-project:
     post:
       operationId: listProjects
       summary: Retrieve a list of projects from GitHub for an organization.
@@ -23,6 +23,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/listProjectsResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+  figma-api/figma-api:
+    post:
+      operationId: figmaApi
+      summary: Retrieve a Figma file as a JSON using its ID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/figmaApiRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/figmaApiResponse'
         "400":
           description: Bad Request
           content:
@@ -48,6 +71,31 @@ components:
           example:
             echarts: "Apache ECharts is a powerful, interactive charting library."
             spark: "Apache Spark - A unified analytics engine for large-scale data processing."
+    figmaApiRequest:
+      type: object
+      properties:
+        fileid:
+          type: string
+          description: The ID of the Figma file.
+          example: "ByHquY48ncR1nQdhhPU7Bj"
+        apitoken:
+          type: string
+          description: The Figma API token.
+          example: "figd_xUC6Aqv5r0berObctWIizA4VhWG5Nmj2EOHFwTum"
+    figmaApiResponse:
+      type: object
+      description: The Figma file retrieved from the API.
+      properties:
+        fileId:
+          type: string
+          description: The ID of the retrieved Figma file.
+        name:
+          type: string
+          description: The name of the retrieved Figma file.
+        nodes:
+          type: object
+          description: The nodes within the Figma file.
+          example: {}
     errorResponse:
       type: object
       properties:


### PR DESCRIPTION
- Code refactoring completed
  - Created `check_errors(response)`
  - Created `list_projects(url, organization, token)`
- Add fix for GitHub API response paginator (max 10 pages)
  - Every page has 100 elements with `name` and `description` fields
- Add default organization name
  - If not provided, the default organization name used will be `apache`
  - If not provided, no error message will be shown with this fix